### PR TITLE
feat(core): experimental API for supporting image inputs in context providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23156,7 +23156,7 @@
     },
     "packages/discord": {
       "name": "@anaplian/discord",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@anaplian/core": "^1.12.3",
@@ -23200,7 +23200,7 @@
     },
     "packages/web": {
       "name": "@anaplian/web",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/packages/core/src/agents/agent-builder.ts
+++ b/packages/core/src/agents/agent-builder.ts
@@ -27,6 +27,7 @@ import {
   InvalidActionError,
   InvalidAgentParametersError,
 } from '../errors/agent-validation-error';
+import { serializeContextToJson } from '../common/serializeContextToJson';
 
 /**
  * Defines the required properties for {@link AgentBuilder}.
@@ -158,7 +159,7 @@ export class AgentBuilder {
    * Constructs the agent and validates. Validation errors will throw {@link AgentValidationError}.
    */
   public readonly build = async (): Promise<AnaplianAgent> => {
-    const serializer = JSON.stringify;
+    const serializer = serializeContextToJson;
     const leftPadding = '\t';
     const modelOutputParser: ModelOutputParser = xmlModelOutputParser;
     const rootFormatter = new RootFormatter({

--- a/packages/core/src/common/__tests__/model-wrappers.test.ts
+++ b/packages/core/src/common/__tests__/model-wrappers.test.ts
@@ -1,6 +1,7 @@
-import { FakeListChatModel, FakeLLM } from '@langchain/core/utils/testing';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
 import { RootFormatter } from '../../formatters/root-formatter';
 import { wrapModel } from '../model-wrappers';
+import { Context } from '../types';
 
 describe('model wrappers', () => {
   const mockRootFormatter: RootFormatter = {
@@ -9,61 +10,51 @@ describe('model wrappers', () => {
     serializeContext: jest.fn().mockReturnValue('{serialized context}'),
   } as unknown as RootFormatter;
 
-  describe('wrapBaseLLM', () => {
-    const mockBaseLlm = new FakeLLM({
-      response: 'FakeLLM mock invocation response',
-    });
-    jest.spyOn(mockBaseLlm, 'invoke');
-    jest.spyOn(mockBaseLlm, 'getNumTokens');
-    const model = wrapModel(mockBaseLlm, mockRootFormatter);
+  const mockChatModel = new FakeListChatModel({
+    responses: ['FakeListChatModel mock invocation response'],
+  });
+  jest.spyOn(mockChatModel, 'invoke');
+  jest.spyOn(mockChatModel, 'getNumTokens');
+  const model = wrapModel(mockChatModel, mockRootFormatter);
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('invokes a LangChain BaseLLM', async () => {
-      expect.assertions(3);
-      const result = await model.invoke({ dinosaur: { today: 't-rex' } });
-      expect(result).toBe('FakeLLM mock invocation response');
-      expect(mockBaseLlm.invoke).toHaveBeenCalledWith('{format}');
-      expect(mockBaseLlm.getNumTokens).not.toHaveBeenCalled();
-    });
-
-    it('checks tokens with a LangChain BaseLLM', async () => {
-      expect.assertions(3);
-      const result = await model.getTokenCount('t-rex');
-      expect(result).toBe(3);
-      expect(mockBaseLlm.invoke).not.toHaveBeenCalled();
-      expect(mockBaseLlm.getNumTokens).toHaveBeenCalledWith('t-rex');
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  describe('wrapChatModel', () => {
-    const mockChatModel = new FakeListChatModel({
-      responses: ['FakeListChatModel mock invocation response'],
-    });
-    jest.spyOn(mockChatModel, 'invoke');
-    jest.spyOn(mockChatModel, 'getNumTokens');
-    const model = wrapModel(mockChatModel, mockRootFormatter);
+  it('invokes a LangChain BaseChatModel', async () => {
+    expect.assertions(3);
+    const result = await model.invoke({ dinosaur: { today: 't-rex' } });
+    expect(result).toBe('FakeListChatModel mock invocation response');
+    expect(mockChatModel.invoke).toHaveBeenCalled();
+    expect(mockChatModel.getNumTokens).not.toHaveBeenCalled();
+  });
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
+  it('checks tokens with a LangChain BaseChatModel', async () => {
+    expect.assertions(3);
+    const result = await model.getTokenCount('t-rex');
+    expect(result).toBe(3);
+    expect(mockChatModel.invoke).not.toHaveBeenCalled();
+    expect(mockChatModel.getNumTokens).toHaveBeenCalledWith('t-rex');
+  });
 
-    it('invokes a LangChain BaseChatModel', async () => {
-      expect.assertions(3);
-      const result = await model.invoke({ dinosaur: { today: 't-rex' } });
-      expect(result).toBe('FakeListChatModel mock invocation response');
-      expect(mockChatModel.invoke).toHaveBeenCalled();
-      expect(mockChatModel.getNumTokens).not.toHaveBeenCalled();
-    });
-
-    it('checks tokens with a LangChain BaseChatModel', async () => {
-      expect.assertions(3);
-      const result = await model.getTokenCount('t-rex');
-      expect(result).toBe(3);
-      expect(mockChatModel.invoke).not.toHaveBeenCalled();
-      expect(mockChatModel.getNumTokens).toHaveBeenCalledWith('t-rex');
-    });
+  it('invokes a LangChain BaseChatModel with images', async () => {
+    expect.assertions(3);
+    const context: Context = {
+      dinosaur: {
+        today: 't-rex',
+        IMAGES: [
+          {
+            annotation: 'This is an image',
+            imageDetail: 'auto',
+            imageType: 'png',
+            imageContent: Buffer.from('some image content'),
+          },
+        ],
+      },
+    };
+    const result = await model.invoke(context);
+    expect(result).toBe('FakeListChatModel mock invocation response');
+    expect(mockChatModel.invoke).toHaveBeenCalledTimes(1);
+    expect(mockChatModel.getNumTokens).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/common/__tests__/serializeContextToJson.test.ts
+++ b/packages/core/src/common/__tests__/serializeContextToJson.test.ts
@@ -1,0 +1,23 @@
+import { serializeContextToJson } from '../serializeContextToJson';
+
+describe('serializeContextToJson', () => {
+  it('serializes to JSON without images', () => {
+    const obj = {
+      content: 'some mock content',
+      IMAGES: [
+        {
+          image: 'this is an image',
+        },
+      ],
+    };
+    expect(serializeContextToJson(obj)).toBe('{"content":"some mock content"}');
+    expect(obj).toStrictEqual({
+      content: 'some mock content',
+      IMAGES: [
+        {
+          image: 'this is an image',
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/src/common/serializeContextToJson.ts
+++ b/packages/core/src/common/serializeContextToJson.ts
@@ -1,0 +1,7 @@
+import { Serializer } from './types';
+
+export const serializeContextToJson: Serializer = (obj) => {
+  const serializableContext = { ...obj };
+  delete serializableContext.IMAGES;
+  return JSON.stringify(serializableContext);
+};

--- a/packages/core/src/common/types.ts
+++ b/packages/core/src/common/types.ts
@@ -1,4 +1,5 @@
 import { ContextProvider } from '../contexts';
+import { ImageDetail } from '@langchain/core/messages';
 
 export type Serializer = (obj: Record<string, unknown>) => string;
 export type ContextErrorCode =
@@ -10,7 +11,37 @@ export type ContextError = {
     readonly message?: string;
   };
 };
-export type Context = Record<string, Record<string, unknown> & ContextError>;
+export type Image = {
+  /**
+   * An annotation provided with the image indicating to the model how it should be interpreted.
+   */
+  readonly annotation: string;
+  /**
+   * Optionally configure the level of detail of the image.
+   */
+  readonly imageDetail?: ImageDetail;
+  /**
+   * Specify what kind of image this is. JPEG and PNG are supported.
+   */
+  readonly imageType: 'png' | 'jpeg';
+  /**
+   * The raw image content as a Buffer.
+   */
+  readonly imageContent: Buffer;
+};
+export type ContextImages = {
+  /**
+   * Optionally, images may be included in partial context. Note that
+   * images are not counted towards the token allocation for this provider
+   * since they cannot be counted prior to inference. The model must be able
+   * to support base64 encoded images.
+   */
+  readonly IMAGES?: Image[];
+};
+export type Context = Record<
+  string,
+  Record<string, unknown> & ContextError & ContextImages
+>;
 export type ContextProviderDocumentation = Omit<
   ContextProvider<string, Record<string, unknown>>,
   'getInitialContext' | 'getNextContext' | 'refresh'
@@ -49,3 +80,5 @@ type BuildTuple<
 export type TupleOfStrings<U extends string> = BuildTuple<
   LengthOfUnion<U> & number
 >;
+export const isDefined = <T>(obj: T | undefined): obj is T =>
+  typeof obj !== 'undefined';

--- a/packages/core/src/contexts/context.ts
+++ b/packages/core/src/contexts/context.ts
@@ -1,4 +1,4 @@
-import { ContextError } from '../common/types';
+import { ContextError, ContextImages } from '../common/types';
 
 /**
  * Object for assisting in generating the next partial context.
@@ -13,7 +13,7 @@ export interface GetNextContextProps<
    * context, there was an error processing the last context update.
    */
   readonly priorContext: Record<string, Record<string, unknown>> &
-    Record<KEY, VALUE & ContextError>;
+    Record<KEY, VALUE & ContextError & ContextImages>;
 
   /**
    * The action that was last taken by the agent.
@@ -58,7 +58,7 @@ export type ContextRefreshProps<
  */
 export interface ContextProvider<
   KEY extends string,
-  VALUE extends Record<string, unknown>,
+  VALUE extends Record<string, unknown> = Record<never, unknown>,
 > {
   /**
    * The ContextProvider should return the next step of this part of the context. If this promise rejects,
@@ -69,8 +69,8 @@ export interface ContextProvider<
    * It will be assigned to KEY in the context object.
    */
   readonly getNextContext: (
-    props: GetNextContextProps<KEY, VALUE>,
-  ) => Promise<VALUE>;
+    props: GetNextContextProps<KEY, VALUE & ContextImages>,
+  ) => Promise<VALUE & ContextImages>;
   /**
    * The initial context provided. If this promise rejects, this is considered a fatal error. This is only invoked
    * once on initial agent boot.
@@ -79,8 +79,8 @@ export interface ContextProvider<
    * @returns {Promise<T extends Record<string, unknown>>} - The initial context partial.
    */
   readonly getInitialContext: (
-    props: GetInitialContextProps<KEY, VALUE>,
-  ) => Promise<VALUE>;
+    props: GetInitialContextProps<KEY, VALUE & ContextImages>,
+  ) => Promise<VALUE & ContextImages>;
   /**
    * This optionally-defined method allows will be called just before the agent takes an action. This is intended for context providers
    * that are independent of the action that the agent takes. For example, if an agent is running inside a cron job that executes hourly,
@@ -89,7 +89,9 @@ export interface ContextProvider<
    * @param {ContextRefreshProps} props - Contains the maximum number of allowed tokens and a utility function for measuring the number of tokens as well as the prior context.
    * @returns {Promise<T extends Record<string, unknown>>} - The initial context partial.
    */
-  readonly refresh?: (props: ContextRefreshProps<KEY, VALUE>) => Promise<VALUE>;
+  readonly refresh?: (
+    props: ContextRefreshProps<KEY, VALUE & ContextImages>,
+  ) => Promise<VALUE & ContextImages>;
   /**
    * Used to assemble the initial context object. This is also referenced to the agent as the name of partial context.
    */


### PR DESCRIPTION
This is an experimental attempt to support image inputs. ContextProviders may now return an optional "IMAGES" field along with their response that will be parsed and injected into the context.